### PR TITLE
Add pi-sdd-kit and an SDD practitioner guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 - [How to write a good spec for AI agents](https://www.oreilly.com/radar/how-to-write-a-good-spec-for-ai-agents/) - Explores why specifications are becoming the most important skill in the age of AI agents.
 
+- [What Is Spec-Driven Development? A Practitioner's Guide](https://felipefontoura.com/articles/what-is-spec-driven-development) - Practitioner guide to SDD: what a spec is, the four pillars, the EARS format, a full worked spec, and when to skip it.
+
 ## Standards
 
 - [agents.md](https://github.com/agentsmd/agents.md) ![](https://img.shields.io/github/stars/agentsmd/agents.md.svg?cacheSeconds=86400) - Markdown-based specification format for defining AI agent behaviors and capabilities.
@@ -53,6 +55,8 @@
 - [fspec](https://github.com/sengac/fspec) ![](https://img.shields.io/github/stars/sengac/fspec.svg?cacheSeconds=86400) - Gherkin-based spec system that auto-generates tests and links code to business rules.
 
 - [MoAI-ADK](https://github.com/modu-ai/moai-adk) ![](https://img.shields.io/github/stars/modu-ai/moai-adk.svg?cacheSeconds=86400) - Framework combining spec-first development, TDD, and AI agents for transparent development lifecycle.
+
+- [pi-sdd-kit](https://github.com/felipefontoura/pi-sdd-kit) ![](https://img.shields.io/github/stars/felipefontoura/pi-sdd-kit.svg?cacheSeconds=86400) - Spec-driven skill pack for the Pi coding agent, with a gated PRD/spec/tasks/review pipeline, steering docs as durable memory, .status approval gates, and EARS requirements.
 
 - [skills](https://github.com/mattpocock/skills) ![](https://img.shields.io/github/stars/mattpocock/skills.svg?cacheSeconds=86400) - Composable engineering skills including PRD/spec, planning, TDD, and architecture workflows for AI-assisted development.
 


### PR DESCRIPTION
Two Spec-Driven Development resources, matched to the list format (alphabetical order, star badge) and placed in the right sections:

- **Development Frameworks** → [pi-sdd-kit](https://github.com/felipefontoura/pi-sdd-kit): an open-source SDD skill pack for the Pi coding agent. Gated PRD/spec/tasks/review pipeline, steering docs as durable project memory, `.status` approval gates, and EARS requirements.
- **Introductions** → [What Is Spec-Driven Development? A Practitioner's Guide](https://felipefontoura.com/articles/what-is-spec-driven-development): a comprehensive, vendor-neutral guide.

Full disclosure: both are mine. I kept them in the correct sections and format, and I'm happy to reword or drop either if you'd prefer. Thanks for maintaining the list!