### PR TITLE
Add Plans to Workflow Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@
 
 ## Workflow Management
 
+- [Plans](https://github.com/yrangana/Plans) ![](https://img.shields.io/github/stars/yrangana/Plans.svg?cacheSeconds=86400) - Markdown convention for tracking multi-feature work with per-feature specs, a status front door, and a static roadmap dashboard.
+
 - [Spec Kitty](https://github.com/Priivacy-ai/spec-kitty) ![](https://img.shields.io/github/stars/Priivacy-ai/spec-kitty.svg?cacheSeconds=86400) - AI development dashboard and workflow automation platform for spec-driven development.
 
 - [taskmaster](https://github.com/eyaltoledano/claude-task-master) ![](https://img.shields.io/github/stars/eyaltoledano/claude-task-master.svg?cacheSeconds=86400) - Task management system for AI-driven development that parses PRDs and orchestrates implementation workflows.


### PR DESCRIPTION
Adds Plans, a markdown convention for tracking multi-feature development work.

  - Each feature gets a markdown file with a seven-field frontmatter spec, a STATUS.md acts as the front door, and a static roadmap.html renders a Gantt chart and dependency graph from the same files with no server or build step.

  - Placed alphabetically at the top of Workflow Management, following the existing entry format.