### PR TITLE
Add THROUGHLINE to Development Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@
 
 - [superpowers](https://github.com/obra/superpowers) ![](https://img.shields.io/github/stars/obra/superpowers.svg?cacheSeconds=86400) - Full software development methodology for coding agents centered on spec approval, planning, and subagent execution.
 
+- [THROUGHLINE](https://github.com/hellomyoh/throughline) ![](https://img.shields.io/github/stars/hellomyoh/throughline.svg?cacheSeconds=86400) - Markdown and git framework where personas debate each spec before code, with an append-only single source of truth that carries decisions across sessions.
+
 ## IDE & Editor Integrations
 
 - [Kiro](https://github.com/kirodotdev/Kiro) ![](https://img.shields.io/github/stars/kirodotdev/Kiro.svg?cacheSeconds=86400) - Agentic IDE for spec-driven development from prototype to production with natural language coding.


### PR DESCRIPTION
Adds [THROUGHLINE](https://github.com/hellomyoh/throughline) to the **Development Frameworks** section, in alphabetical order (after `superpowers`).

THROUGHLINE is a spec-driven development framework for AI coding agents built entirely from markdown and git — no runtime, CLI, or dependencies. Two things distinguish it:

- **Personas debate each spec before code.** A spec is reviewed from several fixed viewpoints and the disagreements are recorded, so trade-offs are settled in the spec rather than discovered in the implementation.
- **An append-only single source of truth carries decisions across sessions.** Earlier decisions stay retrievable in later sessions instead of being silently overwritten.

The repository includes runnable benchmark pilots for both claims, with the caveats stated in the results summary. Works with Claude Code, Codex, and Cursor. Documentation in English and Korean. MIT licensed.

Entry follows the section format (name, star badge, one-sentence description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)