### PR TITLE
Add RailWarden to workflow management

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@
 
 - [Plans](https://github.com/yrangana/Plans) ![](https://img.shields.io/github/stars/yrangana/Plans.svg?cacheSeconds=86400) - Markdown convention for tracking multi-feature work with per-feature specs, a status front door, and a static roadmap dashboard.
 
+- [RailWarden](https://github.com/advaith-1212/railwarden) ![](https://img.shields.io/github/stars/advaith-1212/railwarden.svg?cacheSeconds=86400) - Deterministic execution and integration control plane for approved multi-agent work: turns plans into dependency-aware isolated work packages, records validation evidence, and gates integration.
+
 - [Spec Kitty](https://github.com/Priivacy-ai/spec-kitty) ![](https://img.shields.io/github/stars/Priivacy-ai/spec-kitty.svg?cacheSeconds=86400) - AI development dashboard and workflow automation platform for spec-driven development.
 
 - [taskmaster](https://github.com/eyaltoledano/claude-task-master) ![](https://img.shields.io/github/stars/eyaltoledano/claude-task-master.svg?cacheSeconds=86400) - Task management system for AI-driven development that parses PRDs and orchestrates implementation workflows.


### PR DESCRIPTION
## Summary

Adds [RailWarden](https://github.com/advaith-1212/railwarden) to the **Workflow Management** section.

## Why it belongs here

RailWarden originated as internal execution infrastructure while building TheMindOverMarket. As our development work began coordinating multiple AI coding harnesses, we needed durable execution state, isolated work packages, mechanical validation evidence, and integration gates, not just task tracking or prompt-level guidance.

The approach proved useful enough internally that we open-sourced it for developers working with serious multi-agent and multi-harness software workflows. RailWarden carries approved plans through dependency-aware execution in isolated Git worktrees, captures validation evidence, and permits integration only after its mechanical gates pass.

Workflow Management is the best fit because RailWarden focuses on controlled execution and integration of approved work, rather than specification authoring itself.

## Scope

This PR adds one alphabetically placed entry to `README.md`; there are no unrelated formatting or content changes.