### PR TITLE
Add ouroboros to Development Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@
 
 - [MoAI-ADK](https://github.com/modu-ai/moai-adk) ![](https://img.shields.io/github/stars/modu-ai/moai-adk.svg?cacheSeconds=86400) - Framework combining spec-first development, TDD, and AI agents for transparent development lifecycle.
 
+- [ouroboros](https://github.com/Q00/ouroboros) ![](https://img.shields.io/github/stars/Q00/ouroboros.svg?cacheSeconds=86400) - Local-first Agent OS that wraps Claude Code, Codex CLI, and other coding agents in a replayable Seed → Ledger → Runtime contract, driven by an interview → seed → execute → evaluate → evolve workflow loop.
+
 - [pi-sdd-kit](https://github.com/felipefontoura/pi-sdd-kit) ![](https://img.shields.io/github/stars/felipefontoura/pi-sdd-kit.svg?cacheSeconds=86400) - Spec-driven skill pack for the Pi coding agent, with a gated PRD/spec/tasks/review pipeline, steering docs as durable memory, .status approval gates, and EARS requirements.
 
 - [skills](https://github.com/mattpocock/skills) ![](https://img.shields.io/github/stars/mattpocock/skills.svg?cacheSeconds=86400) - Composable engineering skills including PRD/spec, planning, TDD, and architecture workflows for AI-assisted development.


### PR DESCRIPTION
Adds [Q00/ouroboros](https://github.com/Q00/ouroboros) to Development Frameworks, alphabetically between MoAI-ADK and pi-sdd-kit.

Ouroboros is a local-first Agent OS built specifically around spec-first AI coding: it wraps Claude Code, Codex CLI, OpenCode, Gemini, and other CLI agents in a replayable Seed → Ledger → Runtime execution contract, with an interview → seed → execute → evaluate → evolve loop. MIT licensed, `pip install ouroboros-ai`.

Disclosure: this PR was opened by an AI coding agent on behalf of the repo owner (@Q00).