### PR TITLE
Add Notula to IDE & Editor Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@
 
 - [Kiro](https://github.com/kirodotdev/Kiro) ![](https://img.shields.io/github/stars/kirodotdev/Kiro.svg?cacheSeconds=86400) - Agentic IDE for spec-driven development from prototype to production with natural language coding.
 
+- [Notula](https://github.com/anetrebskii/notula-releases) ![](https://img.shields.io/github/stars/anetrebskii/notula-releases.svg?cacheSeconds=86400) - Desktop WYSIWYG editor for the Markdown specs already in a git repository. Review threads are committed beside each document as an append-only log rather than written into the file, and a comment addressed to `@ai` is answered by the coding agent in the thread.
+
 - [spec-kit-command-cursor](https://github.com/madebyaris/spec-kit-command-cursor) ![](https://img.shields.io/github/stars/madebyaris/spec-kit-command-cursor.svg?cacheSeconds=86400) - Spec-driven development toolkit for Cursor IDE that turns ideas into specs, plans, and actionable tasks.
 
 ## MCP Servers

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@
 
 - [Kiro](https://github.com/kirodotdev/Kiro) ![](https://img.shields.io/github/stars/kirodotdev/Kiro.svg?cacheSeconds=86400) - Agentic IDE for spec-driven development from prototype to production with natural language coding.
 
-- [Notula](https://github.com/anetrebskii/notula-releases) ![](https://img.shields.io/github/stars/anetrebskii/notula-releases.svg?cacheSeconds=86400) - Desktop WYSIWYG editor for the Markdown specs already in a git repository. Review threads are committed beside each document as an append-only log rather than written into the file, and a comment addressed to `@ai` is answered by the coding agent in the thread.
+- [Notula](https://github.com/anetrebskii/notula-releases) ![](https://img.shields.io/github/stars/anetrebskii/notula-releases.svg?cacheSeconds=86400) - WYSIWYG editor for the Markdown specs in a git repository, with review threads committed beside the documents rather than written into them, and a comment addressed to `@ai` answered by the coding agent in the thread.
 
 - [spec-kit-command-cursor](https://github.com/madebyaris/spec-kit-command-cursor) ![](https://img.shields.io/github/stars/madebyaris/spec-kit-command-cursor.svg?cacheSeconds=86400) - Spec-driven development toolkit for Cursor IDE that turns ideas into specs, plans, and actionable tasks.
 


### PR DESCRIPTION
Adds **Notula** to IDE & Editor Integrations, alphabetically between Kiro and spec-kit-command-cursor.

Notula is a free desktop editor for the Markdown that already lives in a git repository, which on a spec-driven project is where the specs are. WYSIWYG with no syntax on screen, and comment threads are committed next to the documents as an append-only log, so a person can mark the three paragraphs that are wrong in a generated spec without opening a pull request. A comment addressed to `@ai` is an ordinary participant in that thread, so the agent answers where the question was asked. It also writes a workspace briefing into `CLAUDE.md` or `AGENTS.md`, and ships a `notula` command with `--json` output over documents, properties, comments and mentions.

The linked repository holds the builds, the release notes and the documentation; the app itself is closed source. Free, no account and no server, macOS and Windows.

I work on Notula.
