### PR TITLE
Add vibe-coding-prompt-template to Specification Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
 
 - [spec-driver](https://github.com/davidlee/spec-driver) ![](https://img.shields.io/github/stars/davidlee/spec-driver.svg?cacheSeconds=86400) - Reimagines specs as evergreen truth systems that emit deltas to conform code to vision.
 
+- [vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template) ![](https://img.shields.io/github/stars/KhazP/vibe-coding-prompt-template.svg?cacheSeconds=86400) - Staged prompts and a CLI that produce a PRD, a technical design, and AGENTS.md before implementation begins.
+
 ## Development Frameworks
 
 - [agent-skills](https://github.com/addyosmani/agent-skills) ![](https://img.shields.io/github/stars/addyosmani/agent-skills.svg?cacheSeconds=86400) - Production-grade skill pack for AI coding agents with explicit spec-to-plan-to-build workflows and quality gates.


### PR DESCRIPTION
Adds one entry to the end of **Specification Tools**.

```markdown
- [vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template) ![](https://img.shields.io/github/stars/KhazP/vibe-coding-prompt-template.svg?cacheSeconds=86400) - Staged prompts and a CLI that produce a PRD, a technical design, and AGENTS.md before implementation begins.
```

**Disclosure:** this is my own project.

Spec-driven in the literal sense: nothing gets built until three documents exist. Staged prompts run the sequence — deep research to check the idea is worth building, then a PRD, then a technical design that picks the surface, stack, and deployment — each stage forcing clarifying questions before it writes. A fourth step compiles the answers into `AGENTS.md` and `agent_docs/`, which is what the coding agent then works from. `npx vibeworkflow` runs the whole sequence as an interview inside the agent.

Closest neighbour already listed is gsd-core, which shares the meta-prompting and spec-first approach; this one starts a stage earlier, at product definition, and ends by emitting the agent instruction files rather than a spec format.

MIT licensed, 2.8k stars, 360+ forks, active development. Format matched to the section, including the star badge and blank-line separation.
