### PR TITLE
Add YYLO to Workflow Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@
 
 - [VibeDoc](https://github.com/JasonRobertDestiny/VibeDoc) ![](https://img.shields.io/github/stars/JasonRobertDestiny/VibeDoc.svg?cacheSeconds=86400) - Documentation tool for spec-driven development workflows.
 
+- [YYLO](https://github.com/yylo-dev/yylo) ![](https://img.shields.io/github/stars/yylo-dev/yylo.svg?cacheSeconds=86400) - Command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries: a dedicated branch/worktree per task, risk-based merge review, and receipt-backed repository changes.
+
 ## Related Lists
 
 - [Awesome Harness Engineering](https://github.com/walkinglabs/awesome-harness-engineering) ![](https://img.shields.io/github/stars/walkinglabs/awesome-harness-engineering.svg?cacheSeconds=86400) - Curated list of articles, playbooks, benchmarks, specs, and open-source projects for harness engineering: shaping the environment around AI agents so they work reliably, with dedicated coverage of specs and agent files.


### PR DESCRIPTION
## What

Adds [YYLO](https://github.com/yylo-dev/yylo) to **Workflow Management** — a command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries: a dedicated branch/worktree per task, risk-based merge review, and receipt-backed repository changes.

## Why it fits this section

- Workflow Management already houses the closest archetypes: RailWarden (plans → dependency-aware isolated work packages, validation evidence, integration gates), Okto Pulse (specs → governed sprints, tasks, and validation gates), and taskmaster (parses PRDs and orchestrates implementation workflows)
- YYLO is the execution side of that loop: each task starts from a frozen target SHA in its own branch/worktree, runs validation there, and lands through a merge queue that owns risk-based review — with run receipts and terminal manifests retained as evidence
- Runs Pi and Codex subagents; MIT-licensed, actively developed since January 2026; installable from npm as `@yylo/cli`

## Changes

- One entry appended at the alphabetical end of Workflow Management (YYLO sorts after VibeDoc)
- Badge format matches the existing entries (`.svg?cacheSeconds=86400`)
- +1 entry, no other edits

## Disclosure

I'm on the YYLO team; this PR was prepared with an AI coding agent, and the description uses only phrasing from the project's README. Happy to re-file under Development Frameworks if that looks like a better home.
