### PR TITLE
Add compendio-mcp to MCP Servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@
 
 ## MCP Servers
 
+- [compendio-mcp](https://github.com/RuloGB/compendio-mcp) ![](https://img.shields.io/github/stars/RuloGB/compendio-mcp.svg?cacheSeconds=86400) - Local hybrid search over a project's spec and doc markdown, so agents read the right section instead of grepping the whole corpus.
+
 - [@reqlan/mcp](https://github.com/littletuna4/reqlan/tree/main/packages/mcp) ![](https://img.shields.io/github/stars/littletuna4/reqlan.svg?cacheSeconds=86400) - Stdio MCP over the same requirement-graph index as the VS Code/Cursor extension and CLI (`npx @reqlan/mcp`).
 
 - [mcp-server-spec-driven-development](https://github.com/formulahendry/mcp-server-spec-driven-development) ![](https://img.shields.io/github/stars/formulahendry/mcp-server-spec-driven-development.svg?cacheSeconds=86400) - MCP server providing structured prompts for requirements, design documents, and code generation.

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@
 
 ## MCP Servers
 
-- [compendio-mcp](https://github.com/RuloGB/compendio-mcp) ![](https://img.shields.io/github/stars/RuloGB/compendio-mcp.svg?cacheSeconds=86400) - Local hybrid search over a project's spec and doc markdown, so agents read the right section instead of grepping the whole corpus.
-
 - [@reqlan/mcp](https://github.com/littletuna4/reqlan/tree/main/packages/mcp) ![](https://img.shields.io/github/stars/littletuna4/reqlan.svg?cacheSeconds=86400) - Stdio MCP over the same requirement-graph index as the VS Code/Cursor extension and CLI (`npx @reqlan/mcp`).
+
+- [compendio-mcp](https://github.com/RuloGB/compendio-mcp) ![](https://img.shields.io/github/stars/RuloGB/compendio-mcp.svg?cacheSeconds=86400) - Local hybrid search over a project's spec and doc markdown, so agents read the right section instead of grepping the whole corpus.
 
 - [mcp-server-spec-driven-development](https://github.com/formulahendry/mcp-server-spec-driven-development) ![](https://img.shields.io/github/stars/formulahendry/mcp-server-spec-driven-development.svg?cacheSeconds=86400) - MCP server providing structured prompts for requirements, design documents, and code generation.
 


### PR DESCRIPTION
Adds compendio-mcp to the MCP Servers section.

It is an MCP server that indexes a project's markdown into a local SQLite index and gives agents hybrid retrieval over it (BM25 + embeddings, merged with Reciprocal Rank Fusion). Three tools: a corpus overview (~10 tokens per document), search, and read-one-section.

Relevant to this list because SDD frameworks produce a growing corpus of spec markdown that agents currently read by grepping and dumping whole files. Compendio indexes any set of roots, so specs and docs can be searched as one corpus (for example "docsDir": ["openspec", "docs"]).

Runs fully locally: CPU embeddings, no API keys, no network calls at query time. MIT, published on npm and in the official MCP registry.