### PR TITLE
Add SpecKit Companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@
 
 - [skills](https://github.com/mattpocock/skills) ![](https://img.shields.io/github/stars/mattpocock/skills.svg?cacheSeconds=86400) - Composable engineering skills including PRD/spec, planning, TDD, and architecture workflows for AI-assisted development.
 
+- [SpecKit Companion pipeline](https://github.com/alfredoperez/speckit-companion/tree/main/speckit-extension) ![](https://img.shields.io/github/stars/alfredoperez/speckit-companion.svg?cacheSeconds=86400) - Configurable layer on top of [Spec Kit](https://github.com/github/spec-kit) rather than a replacement for it. Its commands are assembled from composable nodes, so one config file attaches your own steps at any point, swaps document templates and re-routes the size decision, and a build writes the pipeline you configured. Records each run to plain JSON for live progress and resume, folds small changes onto a shorter path, and keeps optional capability-scoped specs that outlive the feature that created them.
+
 - [superpowers](https://github.com/obra/superpowers) ![](https://img.shields.io/github/stars/obra/superpowers.svg?cacheSeconds=86400) - Full software development methodology for coding agents centered on spec approval, planning, and subagent execution.
 
 - [THROUGHLINE](https://github.com/hellomyoh/throughline) ![](https://img.shields.io/github/stars/hellomyoh/throughline.svg?cacheSeconds=86400) - Markdown and git framework where personas debate each spec before code, with an append-only single source of truth that carries decisions across sessions.
@@ -79,6 +81,8 @@
 - [Notula](https://github.com/anetrebskii/notula-releases) ![](https://img.shields.io/github/stars/anetrebskii/notula-releases.svg?cacheSeconds=86400) - WYSIWYG editor for the Markdown specs in a git repository, with review threads committed beside the documents rather than written into them, and a comment addressed to `@ai` answered by the coding agent in the thread.
 
 - [spec-kit-command-cursor](https://github.com/madebyaris/spec-kit-command-cursor) ![](https://img.shields.io/github/stars/madebyaris/spec-kit-command-cursor.svg?cacheSeconds=86400) - Spec-driven development toolkit for Cursor IDE that turns ideas into specs, plans, and actionable tasks.
+
+- [SpecKit Companion](https://github.com/alfredoperez/speckit-companion) ![](https://img.shields.io/github/stars/alfredoperez/speckit-companion.svg?cacheSeconds=86400) - Spec workspace in VS Code for [Spec Kit](https://github.com/github/spec-kit) runs: specs rendered as structured documents with pull-request-style inline review, a sidebar showing where every feature stands, runs watched live, and the record a finished run leaves behind. A visual pipeline builder makes the workflow itself editable: reorder steps, attach your own, swap document templates, and keep several named workflows per repository.
 
 ## MCP Servers
 


### PR DESCRIPTION
Two entries from the same project, in the two sections they belong to. There is precedent for this in the list already: `reqlan` appears both as the tool and as `@reqlan/mcp` for its MCP package.

**[SpecKit Companion](https://github.com/alfredoperez/speckit-companion)** under *IDE & Editor Integrations* — the VS Code half. A spec workspace: specs rendered as structured documents with pull-request-style inline review, a sidebar for where every feature stands, live run view, and a visual pipeline builder for editing the workflow itself.

**[SpecKit Companion pipeline](https://github.com/alfredoperez/speckit-companion/tree/main/speckit-extension)** under *Development Frameworks* — the Spec Kit extension half, which needs no editor at all. This is the part that is genuinely distinct from the rest of the list: the four commands are assembled from composable nodes, so a project attaches its own steps at any point, swaps document templates and re-routes the size decision from one config file, then builds the pipeline it configured rather than forking the commands. It also records each run to plain JSON for progress and resume, and keeps optional capability-scoped specs that outlive the feature that created them.

Listing them separately because someone working only in a terminal would never look under IDE integrations, and the pipeline half is the more interesting contribution.

MIT licensed, published on the VS Code Marketplace, docs at https://speckit-companion.dev.

Happy to collapse into one entry, or move either, if you would rather. Thanks for keeping this list, it is a genuinely useful map of the space.